### PR TITLE
Fix crash caused by screensaver or display sleep

### DIFF
--- a/Antumbra/AGlowManager.m
+++ b/Antumbra/AGlowManager.m
@@ -79,6 +79,13 @@
     NSLog(@"mirror");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
+	if (!first) {
+		int64_t secondsToWaitBeforeRepeat = 3;
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(secondsToWaitBeforeRepeat * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[self colorFromGlow:glow];
+		});
+		return;
+	}
     GPUImagePicture *pic = [[GPUImagePicture alloc]initWithCGImage:first];
     GPUImageAverageColor *average = [[GPUImageAverageColor alloc]init];
     [pic addTarget:average];
@@ -100,6 +107,13 @@
     NSLog(@"augmenting");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
+	if (!first) {
+		int64_t secondsToWaitBeforeRepeat = 2;
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(secondsToWaitBeforeRepeat * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[self augmentFromGlow:glow];
+		});
+		return;
+	}
     GPUImagePicture *pic = [[GPUImagePicture alloc]initWithCGImage:first];
     GPUImageSaturationFilter *sat = [[GPUImageSaturationFilter alloc]init];
     sat.saturation = 2.0;
@@ -125,6 +139,13 @@
     NSLog(@"balanced");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
+	if (!first) {
+		int64_t secondsToWaitBeforeRepeat = 3;
+		dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(secondsToWaitBeforeRepeat * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+			[self augmentFromGlow:glow];
+		});
+		return;
+	}
     GPUImagePicture *pic = [[GPUImagePicture alloc]initWithCGImage:first];
     GPUImageSaturationFilter *sat = [[GPUImageSaturationFilter alloc]init];
     sat.saturation = 1.5;

--- a/Antumbra/AGlowManager.m
+++ b/Antumbra/AGlowManager.m
@@ -76,7 +76,6 @@
         [[NSNotificationCenter defaultCenter]postNotificationName:@"doneMirroring" object:nil];
         return;
     }
-    NSLog(@"mirror");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
 	if (!first) {
@@ -104,7 +103,6 @@
         [[NSNotificationCenter defaultCenter]postNotificationName:@"doneMirroring" object:nil];
         return;
     }
-    NSLog(@"augmenting");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
 	if (!first) {
@@ -136,7 +134,6 @@
         [[NSNotificationCenter defaultCenter]postNotificationName:@"doneMirroring" object:nil];
         return;
     }
-    NSLog(@"balanced");
     CGDirectDisplayID disp = (CGDirectDisplayID) [[[glow.mirrorAreaWindow.screen deviceDescription]objectForKey:@"NSScreenNumber"] intValue];
     CGImageRef first = CGDisplayCreateImageForRect(disp, glow.mirrorAreaWindow.frame);
 	if (!first) {

--- a/Antumbra/AGlowManager.m
+++ b/Antumbra/AGlowManager.m
@@ -95,7 +95,7 @@
         });
     }];
     [pic processImage];
-    CFRelease(first);
+    CGImageRelease(first);
 }
 
 -(void)augmentFromGlow:(AGlow *)glow{
@@ -125,7 +125,7 @@
         });
     }];
     [pic processImage];
-    CFRelease(first);
+    CGImageRelease(first);
 }
 
 
@@ -157,7 +157,7 @@
         });
     }];
     [pic processImage];
-    CFRelease(first);
+    CGImageRelease(first);
 }
 
 

--- a/Antumbra/AXStatusItemPopup.m
+++ b/Antumbra/AXStatusItemPopup.m
@@ -204,8 +204,6 @@
 }
 
 -(void)mouseMoved:(NSEvent *)theEvent{
-    NSPoint locationInView = [self convertPoint:[theEvent locationInWindow]fromView:nil];
-    NSLog(@"%f %f",locationInView.x,locationInView.y);
 }
 
 @end


### PR DESCRIPTION
When the display goes to sleep (or the screensaver starts) the
macantumbra application crashes as the CGDisplayCreateImageForRect()
function returned NULL.

The fix checks to see if the image returned from
CGDisplayCreateImageForRect is NULL, in this case it handles the error
by not proceeding with the application logic. It then calls the same
function after a delay of some seconds.

With this fix the antumbra device is supposed to stop glowing
while the display is off, but the results depend on CGSHWCaptureDesktop,
called by the CGDisplayCreateImageForRect, which sometimes produces an
error. In that case the antumbra device glows at full brightness.

Signed-off-by: Georges Boumis developer.george.boumis@gmail.com
